### PR TITLE
Fixed segmentation fault on empty spike trains

### DIFF
--- a/pymuvr/Van_Rossum_Multiunit.cpp
+++ b/pymuvr/Van_Rossum_Multiunit.cpp
@@ -417,6 +417,9 @@ void markage(vector<double> & f, vector<double> & e_pos, vector<double> & e_neg,
   
   f.resize(train_size);
   
+  if (train_size == 0)
+    return;
+
   f[0]=0;
 
   for(unsigned int i=1;i<train_size ;++i)

--- a/pymuvr/test/test_pymuvr.py
+++ b/pymuvr/test/test_pymuvr.py
@@ -38,15 +38,18 @@ class TestDistanceMatrix(unittest.TestCase):
         self.observations = [[simple_train(mean_isi, max_duration) for c in range(n_cells)] for o in range(n_observations)]
         # observation 1 is identical to observation 0 for all the cells.
         self.observations[0] = self.observations[1][:]
+
     def test_square_distance_matrix(self):
         d = pymuvr.square_distance_matrix(self.observations, self.cos, self.tau)
         self.assertEqual(d.shape, (len(self.observations), len(self.observations)))
+
     def test_distance_matrix(self):
         d = pymuvr.distance_matrix(self.observations[:3],
                                    self.observations[3:],
                                    self.cos,
                                    self.tau)
         self.assertEqual(d.shape, (3, len(self.observations)-3))
+
     @unittest.skipIf(not NUMPY_IS_AVAILABLE, "can't import numpy")
     def test_compare_square_and_rectangular(self):
         d_rectangular = pymuvr.distance_matrix(self.observations,
@@ -58,6 +61,15 @@ class TestDistanceMatrix(unittest.TestCase):
                                                  self.tau)
 
         np.testing.assert_array_almost_equal(d_rectangular, d_square)
+
+    @unittest.skipIf(not NUMPY_IS_AVAILABLE, "can't import numpy")
+    def test_empty_spike_train(self):
+        # Regression test: This segfaulted in the C++ code
+        observations = [o[:] for o in self.observations]
+        observations[0][0] = []
+        d_rectangular = pymuvr.distance_matrix(observations[:3],
+                                               observations[3:],
+                                               self.cos, self.tau)
 
 @unittest.skipIf(not SPYKEUTILS_IS_AVAILABLE or not NUMPY_IS_AVAILABLE,
                  "can't import spykeutils or numpy, or both")


### PR DESCRIPTION
A simple fix and associated regression test for a segmentation fault that occurred if a passed spike train has no spikes.
