### PR TITLE
Fix: compiling on MSVC

### DIFF
--- a/src/Van_Rossum_Multiunit.cpp
+++ b/src/Van_Rossum_Multiunit.cpp
@@ -3,7 +3,19 @@
 #include<cmath>
 #include<iostream>
 
+#ifdef _MSC_VER
+#include <float.h>
+#endif
+
 #include "Van_Rossum_Multiunit.hpp"
+
+// Microsoft compiler does not have isfinite, but _isnan() instead
+#ifdef _MSC_VER
+bool isfinite(long double x)
+{
+    return !_isnan(x);
+}
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
Visual Studio does not have an isfinite() function, this PR uses an alternative to make pymuvr compile on Windows.
